### PR TITLE
Update sim skill for cli PRs #51, #52, #53

### DIFF
--- a/skills/sim/SKILL.md
+++ b/skills/sim/SKILL.md
@@ -125,7 +125,8 @@ Each Sim API request consumes compute units based on the complexity and number o
 | `dune sim evm collectibles <addr>` | ERC721/ERC1155 NFT holdings with spam filtering | Yes |
 | `dune sim evm token-info <addr>` | Token metadata, price, supply, market cap | Yes |
 | `dune sim evm token-holders <addr>` | Top holders of an ERC20 token ranked by balance | Yes |
-| `dune sim evm defi-positions <addr>` | DeFi positions across lending, AMM, vault protocols (beta) | Yes |
+| `dune sim evm defi-positions <addr>` | DeFi positions across lending, AMM, vault protocols | Yes |
+| `dune sim evm supported-protocols` | DeFi protocol families and chains supported by `defi-positions` | Yes |
 | `dune sim svm balances <addr>` | SPL token balances on Solana/Eclipse (beta) | Yes |
 | `dune sim svm transactions <addr>` | Solana transaction history (beta) | Yes |
 
@@ -229,6 +230,18 @@ dune sim evm defi-positions 0xd8da6bf26964af9d7eed9e03e53415d37aa96045 -o json
 
 # Restrict to Ethereum and Base
 dune sim evm defi-positions 0xd8da... --chain-ids 1,8453 -o json
+```
+
+### Discover DeFi Protocol Coverage
+
+Check which protocol families, sub-protocols, and chains are supported by `defi-positions` before querying a wallet:
+
+```bash
+# Stable protocols/chains only
+dune sim evm supported-protocols -o json
+
+# Include chains still in preview
+dune sim evm supported-protocols --include-preview-chains -o json
 ```
 
 ### Solana Wallet Lookup

--- a/skills/sim/references/evm-balances.md
+++ b/skills/sim/references/evm-balances.md
@@ -33,6 +33,7 @@ dune sim evm balances <address> [flags]
 | `--asset-class` | `string` | No | -- | Filter by asset classification: `stablecoin` |
 | `--metadata` | `string` | No | -- | Request additional fields (comma-separated): `logo`, `url`, `pools` |
 | `--exclude-spam` | `bool` | No | `false` | Exclude low-liquidity tokens (< $100 pool size) |
+| `--exclude-unpriced` | `bool` | No | `true` | Exclude tokens without a USD price. Pass `--exclude-unpriced=false` to include them. |
 | `--historical-prices` | `string` | No | -- | Include historical USD prices at hour offsets (e.g. `720,168,24` for 30d, 7d, 1d ago) |
 | `--limit` | `int` | No | server default | Max results per page (1-1000) |
 | `--offset` | `string` | No | -- | Pagination cursor from previous response's `next_offset` |
@@ -49,7 +50,7 @@ Use `-o json` to get the full structured response. The text table shows chain, s
 ### Examples
 
 ```bash
-# All token balances across default chains
+# All token balances across default chains (priced tokens only by default)
 dune sim evm balances 0xd8da6bf26964af9d7eed9e03e53415d37aa96045 -o json
 
 # Ethereum and Base only, exclude spam
@@ -60,6 +61,9 @@ dune sim evm balances 0xd8da... --filters erc20 --metadata logo -o json
 
 # Include historical prices (30d, 7d, 1d)
 dune sim evm balances 0xd8da... --historical-prices 720,168,24 -o json
+
+# Include tokens without a USD price (full token list, not just priced)
+dune sim evm balances 0xd8da... --exclude-unpriced=false -o json
 ```
 
 ---
@@ -131,6 +135,7 @@ Same as `evm balances` (except `--asset-class` which is automatically set to `st
 | `--filters` | `string` | No | -- | Token filter: `erc20` or `native` |
 | `--metadata` | `string` | No | -- | Additional fields: `logo`, `url`, `pools` |
 | `--exclude-spam` | `bool` | No | `false` | Exclude low-liquidity tokens |
+| `--exclude-unpriced` | `bool` | No | `true` | Exclude tokens without a USD price. Pass `--exclude-unpriced=false` to include them. |
 | `--historical-prices` | `string` | No | -- | Hour offsets for historical prices |
 | `--limit` | `int` | No | server default | Max results per page (1-1000) |
 | `--offset` | `string` | No | -- | Pagination cursor |

--- a/skills/sim/references/evm-defi.md
+++ b/skills/sim/references/evm-defi.md
@@ -10,8 +10,6 @@ Query DeFi positions across lending, AMM, and vault protocols for an EVM wallet.
 
 Return DeFi positions for a wallet address across supported EVM chains and protocols. Each position includes USD valuation and protocol-specific metadata. The response also includes aggregation summaries with total USD value and per-chain breakdowns.
 
-**Note:** This endpoint is in beta (served under `/beta/evm/defi/positions/*`).
-
 ```bash
 dune sim evm defi-positions <address> [flags]
 ```
@@ -67,6 +65,58 @@ dune sim evm defi-positions 0xd8da... --chain-ids 1,8453 -o json
 - Position types are polymorphic -- different types have different fields. Always check the `type` field to know which additional fields are available.
 - Token fields (`token`, `underlying_token`, `token0`, `token1`) are nested objects, not flat strings. Access symbol via `token.symbol`, price via `token.price_usd`, etc.
 - Concentrated liquidity positions (Nft/NftV4) may have multiple sub-positions in the `positions` array, each representing a different tick range. Each sub-position has its own `token0` and `token1` objects with `holdings` and `rewards`.
+
+---
+
+## evm supported-protocols
+
+List the DeFi protocol families, sub-protocols, and chains that `evm defi-positions` can return data for. Use this to discover coverage before querying a wallet.
+
+```bash
+dune sim evm supported-protocols [flags]
+```
+
+### Arguments
+
+None.
+
+### Flags
+
+| Flag | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `--include-preview-chains` | `bool` | No | `false` | Include chains marked as preview (not yet publicly available) |
+| `--include-preview-protocols` | `bool` | No | `false` | Include protocols marked as preview on the requested chains |
+| `-o, --output` | `string` | No | `text` | Output format: `text` or `json` |
+
+### Response
+
+Returns `protocol_families[]`, where each family contains:
+
+- `family` -- protocol family name (e.g. `aave`, `uniswap`)
+- `chains[]` -- each with `chain_id`, `chain_name`, and `status` (`stable` or `preview`)
+- `sub_protocols[]` -- recognized forks / sub-protocols within the family
+
+The text table has columns `FAMILY | CHAINS | SUB_PROTOCOLS`. Chain entries render as `name(id)` with a `*` suffix indicating preview status.
+
+Use `-o json` for the full structured response.
+
+### Examples
+
+```bash
+# Stable protocols / chains only
+dune sim evm supported-protocols -o json
+
+# Include preview chains
+dune sim evm supported-protocols --include-preview-chains -o json
+
+# Include preview protocols too
+dune sim evm supported-protocols --include-preview-chains --include-preview-protocols -o json
+```
+
+### Tips
+
+- Run this before `evm defi-positions` whenever the user asks "is protocol X / chain Y covered?".
+- Preview entries aren't guaranteed to return data from `defi-positions` yet; treat them as coverage roadmap rather than current state.
 
 ---
 


### PR DESCRIPTION
## Summary

Align the `sim` skill with three open [`duneanalytics/cli`](https://github.com/duneanalytics/cli) PRs that change the `dune sim evm` surface:

- **cli#51** — `defi-positions` moves from `/beta/evm/defi/positions/*` to `/v1/evm/defi/positions/*`. Beta note dropped from skill docs.
- **cli#52** — New `dune sim evm supported-protocols` command (flags: `--include-preview-chains`, `--include-preview-protocols`). Added to the command table, a new workflow snippet in SKILL.md, and a dedicated section in `evm-defi.md`.
- **cli#53** — New `--exclude-unpriced` bool flag (default `true`) on `dune sim evm balances` / `stablecoins`. Documented in both flag tables in `evm-balances.md`, plus an example.

## Files touched

- `skills/sim/SKILL.md`
- `skills/sim/references/evm-defi.md`
- `skills/sim/references/evm-balances.md`

## Test plan

- [x] `grep -n "beta" skills/sim/SKILL.md skills/sim/references/evm-defi.md` — no more `(beta)` on `defi-positions` (remaining matches are SVM, intentional)
- [x] `grep -n "supported-protocols" skills/sim/...` — appears in command table, workflow, and reference section
- [x] `grep -n "exclude-unpriced" skills/sim/references/evm-balances.md` — in both `balances` and `stablecoins` flag tables plus an example
- [x] Manual spot-check: flag / command spellings match the PR diffs exactly