### PR TITLE
Add dune-design skill and multichain analytics patterns

### DIFF
--- a/skills/dune-design/SKILL.md
+++ b/skills/dune-design/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: dune-design
+description: "Restyle Dune dashboard charts via browser JavaScript — change colors, fix palettes, update seriesOptions, and batch-apply brand colors across visualizations. Use this skill whenever asked to: update chart colors, fix inconsistent palettes, apply brand colors to a Dune dashboard, change a chart type, update visualization options (stacking, legend, axis labels, number formats), or make a Dune dashboard look consistent. This skill works directly in the browser without needing a Dune API key — it reuses the JWT from the user's active session."
+compatibility: Requires the Claude in Chrome extension and an active Dune browser tab where the user is logged in. Works on any OS.
+allowed-tools: mcp__Claude_in_Chrome__javascript_tool mcp__Claude_in_Chrome__computer mcp__Claude_in_Chrome__navigate mcp__Claude_in_Chrome__tabs_context_mcp
+metadata:
+  author: achillekrtf
+  version: "1.0.0"
+---
+
+# Dune Design Skill
+
+Update Dune chart visualizations (colors, styles, options) by calling Dune's internal GraphQL API directly from the user's browser tab. No API key required — the skill reuses the JWT already held by the browser session.
+
+## How it works
+
+Dune's chart editor calls a `EditVisual` GraphQL mutation at `https://dune.com/public/graphql`. This is a same-domain endpoint (no CORS). The skill:
+1. Installs a `fetch` interceptor in the Dune tab to capture the JWT when the next mutation fires
+2. Triggers one throwaway UI mutation (color picker change) to harvest the JWT
+3. Uses those headers to batch-fire real `EditVisual` mutations with the correct options
+
+> **Why not use the Dune CLI or REST API?** The `api.dune.com` endpoint is CORS-blocked from browser JS, and the Dune CLI does not expose chart color or `seriesOptions` editing. The internal GraphQL API is the only way to update these fields programmatically.
+
+---
+
+## Prerequisites
+
+- Claude in Chrome extension active, with the user on any `dune.com` page
+- The target visualization must be owned by the logged-in user
+- Find viz IDs by opening a chart's editor — the viz ID appears in the URL: `https://dune.com/queries/<queryId>/<vizId>`
+
+---
+
+## Step-by-step workflow
+
+### 1. Get the tab ID
+
+```js
+// Use tabs_context_mcp to find the dune.com tab
+```
+
+### 2. Navigate to the target query/viz page
+
+```
+https://dune.com/queries/<queryId>/<vizId>
+```
+
+### 3. Install the fetch interceptor
+
+Run once — patches `window.fetch` to log every `EditVisual` mutation to `window._gqlLog`:
+
+```javascript
+window._gqlLog = [];
+const _origFetch = window.fetch;
+window.fetch = function(...args) {
+  const [url, opts] = args;
+  if (url && url.toString().includes('EditVisual') && opts && opts.body) {
+    window._gqlLog.push({
+      url: url.toString(),
+      headers: JSON.stringify(Object.fromEntries(
+        (opts.headers instanceof Headers)
+          ? opts.headers.entries()
+          : Object.entries(opts.headers || {})
+      )),
+      body: opts.body
+    });
+  }
+  return _origFetch.apply(this, args);
+};
+'interceptor installed';
+```
+
+### 4. Trigger a throwaway mutation to capture auth headers
+
+Open the color picker in the chart editor UI, then trigger a value change to fire a mutation:
+
+```javascript
+const inp = document.querySelector('.OptionInputColor-module__UcMDpW__colorInput');
+const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+setter.call(inp, '#FFFFFF');
+inp.dispatchEvent(new Event('input', { bubbles: true }));
+inp.dispatchEvent(new Event('change', { bubbles: true }));
+inp.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', keyCode: 13, bubbles: true }));
+inp.dispatchEvent(new KeyboardEvent('keyup',  { key: 'Enter', keyCode: 13, bubbles: true }));
+```
+
+**Alternative:** manually click any color swatch in the Dune UI — it fires the mutation automatically.
+
+### 5. Extract the auth headers
+
+```javascript
+const captured = window._gqlLog[0];
+// Headers are serialized as a JSON string — always JSON.parse() first
+const h = JSON.parse(captured.headers);
+// h.authorization       → Bearer JWT
+// h['x-dune-access-token'] → JWT
+```
+
+### 6. Fire the EditVisual mutation
+
+```javascript
+const GQL = 'https://dune.com/public/graphql?operationName=EditVisual';
+const MUTATION = `mutation EditVisual($input: UpdateVisualizationInput!) {
+  updateVisualization(input: $input) { id type name options __typename }
+}`;
+
+const result = await fetch(GQL, {
+  method: 'POST',
+  headers: {
+    'accept':               h['accept'],
+    'content-type':         'application/json',
+    'authorization':        h['authorization'],
+    'x-dune-access-token':  h['x-dune-access-token']
+  },
+  body: JSON.stringify({
+    operationName: 'EditVisual',
+    variables: {
+      input: {
+        id:          <vizId>,        // integer
+        type:        'chart',
+        name:        'Chart Name',   // required — omitting causes a 400 error
+        description: '',
+        options:     <optionsObject>
+      }
+    },
+    extensions: { clientLibrary: { name: '@apollo/client', version: '4.1.6' } },
+    query: MUTATION
+  })
+}).then(r => r.json());
+
+result.data?.updateVisualization?.id  // confirm success
+```
+
+### 7. Batch-update multiple charts
+
+Reuse the same captured headers — they stay valid for the whole session:
+
+```javascript
+const updates = [
+  { id: 12345, name: 'TVL by Product', options: { ...TVL_OPTS } },
+  { id: 12346, name: 'Holder Count',   options: { ...HOLDER_OPTS } },
+];
+
+for (const u of updates) {
+  const res = await fetch(GQL, {
+    method: 'POST',
+    headers: { 'accept': h.accept, 'content-type': 'application/json',
+                'authorization': h.authorization, 'x-dune-access-token': h['x-dune-access-token'] },
+    body: JSON.stringify({
+      operationName: 'EditVisual',
+      variables: { input: { id: u.id, type: 'chart', name: u.name, description: '', options: u.options } },
+      extensions: { clientLibrary: { name: '@apollo/client', version: '4.1.6' } },
+      query: MUTATION
+    })
+  }).then(r => r.json());
+  console.log(u.name, res.data?.updateVisualization?.id ? 'OK' : res.errors);
+}
+```
+
+---
+
+## chartStyles.colorPalettes
+
+The `colorPalettes` field in `chartStyles` controls how `seriesOptions[name].color` is applied:
+
+| Value | Behavior |
+|---|---|
+| `'custom'` | Respects `seriesOptions[name].color` for **all** series names |
+| `'autoBrandColors'` | Only applies `seriesOptions.color` for recognized product names. For generic labels (e.g. `"Micro (<1K)"`, `"bucket_1"`), color is ignored. |
+| `'defaultColors'` | Dune assigns colors sequentially — no custom control |
+
+**Rule:** Use `'custom'` for any chart with bucket labels, cohort names, or non-product series. Use `'autoBrandColors'` only when all series names are recognized Dune product/protocol names.
+
+---
+
+## Reading current options before overwriting
+
+Always fetch the current options before replacing them to avoid losing axis config or number formats:
+
+```javascript
+const res = await fetch('https://dune.com/public/graphql?operationName=GetVisualization', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({
+    operationName: 'GetVisualization',
+    variables: { id: <vizId> },
+    query: `query GetVisualization($id: Int!) {
+      visualization(id: $id) { id name type options }
+    }`
+  })
+}).then(r => r.json());
+console.log(JSON.stringify(res.data.visualization.options, null, 2));
+```
+
+---
+
+## Known gotchas
+
+1. **`name` is required.** Omitting it causes `"Field 'name' of required type 'String!' was not provided"`.
+2. **Headers are a JSON string.** Always `JSON.parse(captured.headers)` before accessing `.authorization`.
+3. **`autoBrandColors` ignores custom colors for non-product series.** Distribution / cohort charts with bucket labels must use `colorPalettes: 'custom'`.
+4. **`api.dune.com` is CORS-blocked.** Always use `dune.com/public/graphql` (same-domain).
+5. **JWT expires with the browser session.** If mutations return 401, the user needs to refresh their login.
+6. **Color picker class name may change.** Use `document.querySelector('input[value^="#"]')` as a fallback if the module class doesn't match.
+7. **`seriesOptions` keys must match query output exactly.** Check the column alias in the SQL to get the real series label strings.
+
+---
+
+## References
+
+- [`references/color-palettes.md`](references/color-palettes.md) — Common color palette patterns and seriesOptions templates
+- [`references/viz-options.md`](references/viz-options.md) — Complete `options` objects for every chart type (stacked bar, area, line, counter, pie, scatter)

--- a/skills/dune-design/references/color-palettes.md
+++ b/skills/dune-design/references/color-palettes.md
@@ -1,0 +1,73 @@
+# Color Palettes for Dune Charts
+
+## Using custom colors
+
+Set `chartStyles: { colorPalettes: 'custom' }` in the visualization options, then assign a color to each series in `seriesOptions`:
+
+```json
+{
+  "chartStyles": { "colorPalettes": "custom" },
+  "seriesOptions": {
+    "Series A": { "type": "area", "color": "#2376FB", "yAxis": 0, "zIndex": 0 },
+    "Series B": { "type": "area", "color": "#FF8B3D", "yAxis": 0, "zIndex": 1 }
+  }
+}
+```
+
+## Wallet size / investor distribution buckets
+
+Blue gradient from light (small) to dark (large). Requires `colorPalettes: 'custom'` — `autoBrandColors` ignores colors for bucket labels.
+
+```json
+{
+  "chartStyles": { "colorPalettes": "custom" },
+  "seriesOptions": {
+    "Micro (<1K)":    { "type": "column", "color": "#CFE0FB", "yAxis": 0, "zIndex": 0 },
+    "Small (1K-10K)": { "type": "column", "color": "#84ABE8", "yAxis": 0, "zIndex": 1 },
+    "Mid (10K-100K)": { "type": "column", "color": "#2376FB", "yAxis": 0, "zIndex": 2 },
+    "Large (100K-1M)":{ "type": "column", "color": "#0D52C9", "yAxis": 0, "zIndex": 3 },
+    "Whale (>1M)":    { "type": "column", "color": "#020202", "yAxis": 0, "zIndex": 4 }
+  }
+}
+```
+
+## Multi-chain breakdown (chain colors)
+
+Widely-used chain color conventions for consistent cross-dashboard styling:
+
+```json
+{
+  "chartStyles": { "colorPalettes": "custom" },
+  "seriesOptions": {
+    "ethereum":  { "type": "area", "color": "#627EEA", "yAxis": 0, "zIndex": 0 },
+    "arbitrum":  { "type": "area", "color": "#28A0F0", "yAxis": 0, "zIndex": 1 },
+    "polygon":   { "type": "area", "color": "#8247E5", "yAxis": 0, "zIndex": 2 },
+    "base":      { "type": "area", "color": "#0052FF", "yAxis": 0, "zIndex": 3 },
+    "optimism":  { "type": "area", "color": "#FF0420", "yAxis": 0, "zIndex": 4 },
+    "bnb":       { "type": "area", "color": "#F0B90B", "yAxis": 0, "zIndex": 5 },
+    "avalanche": { "type": "area", "color": "#E84142", "yAxis": 0, "zIndex": 6 },
+    "solana":    { "type": "area", "color": "#9945FF", "yAxis": 0, "zIndex": 7 },
+    "stellar":   { "type": "area", "color": "#000000", "yAxis": 0, "zIndex": 8 }
+  }
+}
+```
+
+## Single-product gradient (light to dark)
+
+Use when you want visual depth on a single product/category across multiple metrics:
+
+```json
+{
+  "chartStyles": { "colorPalettes": "custom" },
+  "seriesOptions": {
+    "metric_1": { "type": "column", "color": "#CFE0FB", "yAxis": 0, "zIndex": 0 },
+    "metric_2": { "type": "column", "color": "#84ABE8", "yAxis": 0, "zIndex": 1 },
+    "metric_3": { "type": "column", "color": "#2376FB", "yAxis": 0, "zIndex": 2 },
+    "metric_4": { "type": "column", "color": "#0D52C9", "yAxis": 0, "zIndex": 3 }
+  }
+}
+```
+
+## Notes on zIndex
+
+`zIndex` controls the draw order of series (higher = drawn on top). For stacked charts, set `zIndex` to match the visual stack order. For non-stacked charts, it controls which series appears in front when they overlap.

--- a/skills/dune-design/references/viz-options.md
+++ b/skills/dune-design/references/viz-options.md
@@ -1,0 +1,175 @@
+# Visualization Options Reference
+
+Complete `options` objects for each Dune chart type. Copy-paste and adjust `columnMapping`, `seriesOptions`, and number formats for your query columns.
+
+---
+
+## Stacked bar chart (distribution / breakdown)
+
+```json
+{
+  "sortX": true,
+  "reverseX": false,
+  "xAxis": { "type": "-" },
+  "yAxis": [{ "type": "linear", "includeZero": true }],
+  "legend": { "enabled": true },
+  "series": { "stacking": "stack", "showTotal": true, "percentValues": false },
+  "chartStyles": { "colorPalettes": "custom" },
+  "globalSeriesType": "column",
+  "numberFormat": "0,0",
+  "numberFormatRightYAxisSeries": "0,0",
+  "valuesOptions": {},
+  "columnMapping": {
+    "<x_column>": "x",
+    "<series_column>": "series",
+    "<value_column>": "y"
+  },
+  "seriesOptions": {
+    "<series_name_1>": { "type": "column", "color": "#2376FB", "yAxis": 0, "zIndex": 0 },
+    "<series_name_2>": { "type": "column", "color": "#0D52C9", "yAxis": 0, "zIndex": 1 }
+  }
+}
+```
+
+Set `"percentValues": true` for a 100% stacked view.
+
+---
+
+## Area / line timeseries
+
+```json
+{
+  "sortX": false,
+  "reverseX": false,
+  "xAxis": { "type": "time" },
+  "yAxis": [{ "type": "linear", "includeZero": true }],
+  "legend": { "enabled": true },
+  "series": { "stacking": "stack" },
+  "chartStyles": { "colorPalettes": "custom" },
+  "globalSeriesType": "area",
+  "numberFormat": "$0,0.00a",
+  "numberFormatRightYAxisSeries": "0,0",
+  "valuesOptions": {},
+  "columnMapping": {
+    "day": "x",
+    "value": "y",
+    "series": "series"
+  },
+  "seriesOptions": {
+    "<series_name>": { "type": "area", "color": "#2376FB", "yAxis": 0, "zIndex": 0 }
+  }
+}
+```
+
+For a **pure line** (no fill), change `"type": "line"` in each series and `"globalSeriesType": "line"`.
+
+---
+
+## Counter (KPI single number)
+
+```json
+{
+  "counterColName": "<value_column>",
+  "rowNumber": 1,
+  "targetRowNumber": 1,
+  "numberFormat": "$0,0.00a",
+  "suffix": "",
+  "prefix": "",
+  "coloredPositiveValues": true
+}
+```
+
+`counterColName` must match the exact column alias in the query output. `rowNumber` is 1-based.
+
+---
+
+## Bar chart (sorted leaderboard)
+
+```json
+{
+  "sortX": true,
+  "reverseX": true,
+  "xAxis": { "type": "-" },
+  "yAxis": [{ "type": "linear", "includeZero": true }],
+  "legend": { "enabled": false },
+  "series": { "stacking": null },
+  "chartStyles": { "colorPalettes": "custom" },
+  "globalSeriesType": "bar",
+  "numberFormat": "$0,0.00a",
+  "valuesOptions": {},
+  "columnMapping": {
+    "<label_column>": "x",
+    "<value_column>": "y"
+  },
+  "seriesOptions": {
+    "<series_name>": { "type": "bar", "color": "#2376FB", "yAxis": 0, "zIndex": 0 }
+  }
+}
+```
+
+---
+
+## Pie chart
+
+```json
+{
+  "globalSeriesType": "pie",
+  "sortX": true,
+  "showDataLabels": true,
+  "chartStyles": { "colorPalettes": "custom" },
+  "legend": { "enabled": true },
+  "numberFormat": "0,0.00a",
+  "columnMapping": {
+    "<label_column>": "x",
+    "<value_column>": "y"
+  },
+  "seriesOptions": {
+    "<value_column>": { "type": "pie", "yAxis": 0, "zIndex": 0 }
+  }
+}
+```
+
+---
+
+## Scatter chart
+
+```json
+{
+  "globalSeriesType": "scatter",
+  "xAxis": { "type": "linear" },
+  "yAxis": [{ "type": "linear", "includeZero": false }],
+  "legend": { "enabled": true },
+  "chartStyles": { "colorPalettes": "custom" },
+  "numberFormat": "0,0.00",
+  "columnMapping": {
+    "<x_column>": "x",
+    "<y_column>": "y",
+    "<series_column>": "series"
+  },
+  "seriesOptions": {}
+}
+```
+
+---
+
+## columnMapping roles
+
+| Role | Meaning |
+|---|---|
+| `"x"` | X-axis (categories, dates, labels) |
+| `"y"` | Y-axis value (one series per `"y"` column, or use `"series"` column for dynamic series) |
+| `"series"` | Dynamic series name (one series per distinct value in this column) |
+| `"size"` | Bubble size (scatter plots) |
+
+---
+
+## Numeral.js format strings
+
+| Format | Output | Use case |
+|---|---|---|
+| `"0,0"` | 1,234 | Integer |
+| `"0,0.00"` | 1,234.56 | Two decimals |
+| `"0.0a"` | 1.2k | Abbreviated |
+| `"$0,0.00a"` | $1.23m | USD abbreviated |
+| `"0%"` | 50% | Percentage |
+| `"0.00%"` | 50.00% | Percentage with decimals |

--- a/skills/dune/SKILL.md
+++ b/skills/dune/SKILL.md
@@ -254,6 +254,7 @@ Load the relevant reference when you need detailed command syntax and flags:
 | Search datasets or find tables for a contract address | [dataset-discovery.md](references/dataset-discovery.md) |
 | Search documentation or check account usage | [docs-and-usage.md](references/docs-and-usage.md) |
 | DuneSQL types, functions, common patterns, and pitfalls | [dunesql-cheatsheet.md](references/dunesql-cheatsheet.md) |
+| Multi-chain supply tracking, Starknet events, Stellar state, fill-forward prices, incremental queries | [multichain-analytics.md](references/multichain-analytics.md) |
 | Create, get, update, delete, or list visualizations on saved queries | [visualization-management.md](references/visualization-management.md) |
 | Create, get, update, or archive dashboards | [dashboard-management.md](references/dashboard-management.md) |
 | CLI install, authentication, and version recovery | [install-and-recovery.md](references/install-and-recovery.md) |

--- a/skills/dune/references/multichain-analytics.md
+++ b/skills/dune/references/multichain-analytics.md
@@ -1,0 +1,249 @@
+# Multi-Chain Analytics Patterns
+
+> **Prerequisite:** Read the [main skill](../SKILL.md) for authentication and the [DuneSQL cheatsheet](dunesql-cheatsheet.md) for core syntax.
+
+Advanced DuneSQL patterns for querying tokens, balances, and events across EVM chains, Starknet, and Stellar.
+
+---
+
+## 1. Cross-chain token supply (mint/burn)
+
+The unified pattern for tracking any ERC-20 token's net supply across all EVM chains via a single query:
+
+```sql
+WITH token_moves AS (
+  SELECT
+    DATE_TRUNC('day', evt_block_time) AS day,
+    blockchain,
+    SUM(CASE
+      WHEN "from" = 0x0000000000000000000000000000000000000000 THEN  CAST(value AS DOUBLE) / 1e18
+      WHEN "to"   = 0x0000000000000000000000000000000000000000 THEN -CAST(value AS DOUBLE) / 1e18
+      ELSE 0
+    END) AS net_change
+  FROM evms.erc20_transfers
+  WHERE evt_block_time >= TIMESTAMP '2024-01-01'
+    AND blockchain IN ('ethereum', 'polygon', 'arbitrum', 'base', 'optimism')
+    AND contract_address = 0x<TOKEN_ADDRESS>
+  GROUP BY 1, 2
+),
+calendar AS (
+  SELECT date_trunc('day', period) AS day
+  FROM UNNEST(SEQUENCE(DATE '2024-01-01', CURRENT_DATE, INTERVAL '1' DAY)) AS t(period)
+),
+cumulative AS (
+  SELECT
+    c.day,
+    SUM(COALESCE(m.net_change, 0)) OVER (ORDER BY c.day) AS net_supply
+  FROM calendar c
+  LEFT JOIN token_moves m ON c.day = m.day
+    AND m.blockchain = 'ethereum'  -- adjust per product
+)
+SELECT day, net_supply FROM cumulative ORDER BY day
+```
+
+**Key points:**
+- `evms.erc20_transfers` is the unified cross-chain ERC-20 table. Always add a `blockchain IN (...)` filter — without it, Dune scans all chains.
+- Mint = transfer FROM the zero address. Burn = transfer TO the zero address.
+- Adjust divisor (1e18, 1e6, 1e5, etc.) to match the token's decimals.
+
+---
+
+## 2. Per-wallet balance reconstruction
+
+Reconstruct current holdings for every wallet from transfer history:
+
+```sql
+WITH all_flows AS (
+  SELECT CAST("to" AS VARCHAR) AS wallet, CAST(value AS DOUBLE) / 1e18 AS amount
+  FROM evms.erc20_transfers
+  WHERE contract_address = 0x<TOKEN>
+    AND "to" != 0x0000000000000000000000000000000000000000
+    AND blockchain = 'ethereum'
+  UNION ALL
+  SELECT CAST("from" AS VARCHAR) AS wallet, -CAST(value AS DOUBLE) / 1e18
+  FROM evms.erc20_transfers
+  WHERE contract_address = 0x<TOKEN>
+    AND "from" != 0x0000000000000000000000000000000000000000
+    AND blockchain = 'ethereum'
+)
+SELECT wallet, SUM(amount) AS balance
+FROM all_flows
+GROUP BY wallet
+HAVING SUM(amount) > 0.001
+ORDER BY balance DESC
+```
+
+---
+
+## 3. Starknet Transfer events
+
+Starknet uses events rather than ERC-20 style logs. The Transfer event structure differs from EVM:
+
+```sql
+SELECT
+  CAST(keys[2] AS VARCHAR) AS sender,
+  CAST(keys[3] AS VARCHAR) AS receiver,
+  CAST(bytearray_to_uint256(data[1]) AS DOUBLE) / 1e18 AS amount
+FROM starknet.events
+WHERE block_date >= DATE '2024-01-01'
+  AND keys[1] = 0x0099cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9  -- Transfer event key
+  AND from_address = 0x<STARKNET_TOKEN_CONTRACT>
+  AND cardinality(keys) >= 3
+  AND cardinality(data) >= 1
+```
+
+- `from_address` = the token contract address (not the sender wallet)
+- `keys[2]` = sender, `keys[3]` = recipient
+- `data[1]` = amount (u256 low word; for Starknet token amounts the high word is always 0)
+- Zero address on Starknet is 64 hex zeros: `0x0000...0000` (64 chars)
+
+---
+
+## 4. Stellar contract state (Soroban)
+
+Stellar/Soroban stores **state snapshots** (balance entries), not transfer events. Each row is a balance at a point in time. To get the **current balance**, take the latest snapshot per holder:
+
+```sql
+WITH latest_balances AS (
+  SELECT
+    json_extract_scalar(key_decoded, '$.vec[1].address') AS holder,
+    TRY_CAST(json_extract_scalar(val_decoded, '$.i128') AS DOUBLE) / 1e7 AS balance,
+    ROW_NUMBER() OVER (
+      PARTITION BY json_extract_scalar(key_decoded, '$.vec[1].address')
+      ORDER BY ledger_sequence DESC
+    ) AS rn
+  FROM stellar.contract_data
+  WHERE contract_id = '<STELLAR_CONTRACT_ID>'
+    AND deleted = false
+    AND contract_key_type = 'ScValTypeScvVec'
+    AND json_extract_scalar(key_decoded, '$.vec[0].symbol') = 'Balance'
+)
+SELECT holder, balance
+FROM latest_balances
+WHERE rn = 1 AND balance > 0
+```
+
+> **Critical:** Always deduplicate with `ROW_NUMBER() ORDER BY ledger_sequence DESC` and keep only `rn = 1`. Stellar stores every historical version of each balance entry — summing without deduplication inflates balances by 40-100x.
+
+---
+
+## 5. Fill-forward prices (oracle NAV)
+
+NAV oracle prices don't update every day. Use `LAST_VALUE ... IGNORE NULLS` to forward-fill:
+
+```sql
+WITH calendar AS (
+  SELECT date_trunc('day', period) AS day
+  FROM UNNEST(SEQUENCE(DATE '2024-01-01', CURRENT_DATE, INTERVAL '1' DAY)) AS t(period)
+),
+daily_prices_sparse AS (
+  SELECT
+    DATE_TRUNC('day', block_time) AS day,
+    ARBITRARY(bytearray_to_uint256(bytearray_substring(data, 33, 32))) * 1e-6 AS nav_price
+  FROM ethereum.logs
+  WHERE contract_address = 0x<ORACLE_ADDRESS>
+    AND topic0 = 0x<PRICE_UPDATE_EVENT>
+    AND block_time >= TIMESTAMP '2024-01-01'
+  GROUP BY 1
+),
+filled_prices AS (
+  SELECT
+    c.day,
+    COALESCE(
+      LAST_VALUE(p.nav_price) IGNORE NULLS OVER (ORDER BY c.day ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+      1.0  -- fallback default
+    ) AS nav_price
+  FROM calendar c
+  LEFT JOIN daily_prices_sparse p ON c.day = p.day
+)
+SELECT * FROM filled_prices ORDER BY day
+```
+
+---
+
+## 6. Incremental query pattern (materialized view)
+
+For queries that get expensive over time, use Dune's incremental pattern to only scan new data on each run:
+
+```sql
+WITH prev AS (
+  SELECT * FROM TABLE(previous.query.result(
+    schema => DESCRIPTOR(
+      day        TIMESTAMP(3),
+      product    VARCHAR,
+      net_supply DOUBLE
+    )
+  ))
+),
+checkpoint AS (
+  SELECT
+    COALESCE(MAX(day), TIMESTAMP '2024-01-01') - INTERVAL '3' DAY AS cutoff,
+    CAST(COALESCE(MAX(day), TIMESTAMP '2024-01-01') - INTERVAL '3' DAY AS DATE) AS cutoff_date
+  FROM prev
+),
+-- ... CTEs for new data, filtered by checkpoint ...
+new_data AS (
+  SELECT day, product, net_supply
+  FROM your_logic_here
+  WHERE day >= (SELECT cutoff_date FROM checkpoint)
+)
+-- Final: union old results with new data
+SELECT * FROM prev
+WHERE day < (SELECT cutoff FROM checkpoint)
+UNION ALL
+SELECT * FROM new_data
+```
+
+**Key rules:**
+- The `DESCRIPTOR` must match your output columns and types exactly
+- Include a 3-day lookback window to handle delayed data ingestion
+- For cumulative metrics (running totals), seed from the last known value in `prev` rather than recomputing from zero
+- Stellar queries always need a full recompute (LAG requires full history) — skip the incremental wrapper for Stellar CTEs
+
+---
+
+## 7. Day × series matrix (prevent gaps)
+
+When a series has no data on certain days, LEFT JOIN against a full calendar to prevent gaps in charts:
+
+```sql
+WITH calendar AS (
+  SELECT date_trunc('day', period) AS day
+  FROM UNNEST(SEQUENCE(DATE '2024-01-01', CURRENT_DATE, INTERVAL '1' DAY)) AS t(period)
+),
+products AS (
+  SELECT product FROM (VALUES ('TokenA'), ('TokenB'), ('TokenC')) AS t(product)
+),
+full_grid AS (
+  SELECT c.day, p.product FROM calendar c CROSS JOIN products p
+)
+SELECT
+  g.day,
+  g.product,
+  COALESCE(d.value, 0) AS value
+FROM full_grid g
+LEFT JOIN your_data d ON g.day = d.day AND g.product = d.product
+ORDER BY 1, 2
+```
+
+---
+
+## 8. Common multi-chain pitfalls
+
+| Pitfall | Fix |
+|---|---|
+| Missing `blockchain` filter on `evms.*` | Always add `AND blockchain IN ('ethereum', ...)` — without it the query scans all chains |
+| Summing Stellar balance rows without deduplication | Use `ROW_NUMBER() OVER (PARTITION BY holder ORDER BY ledger_sequence DESC)` and keep `rn = 1` |
+| LAG inside a GROUP BY CTE | Trino forbids this — put the LAG in a separate CTE, then GROUP BY in the next one |
+| `ORDER BY` without `LIMIT` on large tables | Sorting millions of rows with no limit is slow and expensive |
+| Hardcoded FX rates | Use on-chain Chainlink/Redstone oracle feeds when available |
+| Using `TIMESTAMP` keyword | Use `CAST('2024-01-01' AS timestamp)` or `DATE '2024-01-01'` instead |
+| Bigint overflow in `gas_used * gas_price` | Cast both to `double` before multiplying |
+
+---
+
+## See Also
+
+- [dunesql-cheatsheet.md](dunesql-cheatsheet.md) — Core DuneSQL syntax and functions
+- [dataset-discovery.md](dataset-discovery.md) — Find the right table before writing SQL
+- [query-management.md](query-management.md) — Save and manage queries via CLI


### PR DESCRIPTION
## Summary

Two contributions in this PR:

### 1. New skill: `dune-design`

A browser-based skill for restyling Dune dashboard charts via the internal GraphQL API — no CLI, no API key required. Works by intercepting Dune's own session JWT and firing `EditVisual` mutations directly from the user's browser tab (via Claude in Chrome).

- `SKILL.md` — fetch interceptor pattern, JWT capture, `EditVisual` mutation workflow, batch-update loop, `colorPalettes` gotchas
- `references/color-palettes.md` — wallet size buckets, chain colors, single-product gradients, `seriesOptions` templates
- `references/viz-options.md` — complete `options` objects for stacked bar, area/line, counter, bar, pie, scatter

**Why this can't be done with the existing `dune` CLI:** The CLI exposes viz create/update but does not surface `chartStyles.colorPalettes` or `seriesOptions.color`. The internal GraphQL API is the only way to set these fields programmatically.

### 2. Enhanced `dune` skill: `references/multichain-analytics.md`

A new reference document for the existing `dune` skill covering advanced multi-chain analytics patterns, distilled from production query work across EVM, Starknet, and Stellar:

- Cross-chain ERC-20 supply via `evms.erc20_transfers` (mint/burn pattern)
- Per-wallet balance reconstruction
- Starknet Transfer events (keys/data structure)
- Stellar `contract_data` deduplication — critical gotcha: always `ROW_NUMBER() ORDER BY ledger_sequence DESC` or balances inflate 40-100x
- Fill-forward NAV prices with `LAST_VALUE IGNORE NULLS`
- Incremental query pattern (`previous.query.result`)
- Day × series matrix to prevent chart gaps
- Multi-chain pitfalls table

## Test plan

- [ ] `dune-design`: open any Dune query page in Chrome, run the interceptor snippet, trigger a color picker change, confirm JWT is captured in `window._gqlLog`, fire a mutation and verify `updateVisualization.id` returns
- [ ] `multichain-analytics.md`: run the Starknet and Stellar patterns against a live query; verify Stellar dedup prevents balance inflation

🤖 Generated with [Claude Code](https://claude.com/claude-code)