### PR TITLE
Add clarification about perf engines

### DIFF
--- a/skills/dune/SKILL.md
+++ b/skills/dune/SKILL.md
@@ -74,12 +74,11 @@ Dune uses **DuneSQL**, a Trino-based SQL dialect, as its query engine. Key point
 
 ### Performance Tiers
 
-Query execution supports two tiers:
+Available tiers: `free`, `medium`, `large`. **Do not pass `--performance` by default** — omit it and the API auto-selects. Only provide it when:
 
-| Tier | Flag Value | Description |
-|------|-----------|-------------|
-| Medium | `medium` (default) | Standard compute resources. Suitable for most queries. |
-| Large | `large` | Higher compute resources. Use for complex queries, large joins, or heavy aggregations. Costs more credits. |
+- The user explicitly requests a tier
+- The query is clearly complex (heavy joins, large aggregations)
+- A previous run returned a timeout or resource-limit error
 
 ### Execution States
 

--- a/skills/dune/references/query-execution.md
+++ b/skills/dune/references/query-execution.md
@@ -31,7 +31,7 @@ dune query run <query-id> [flags]
 | Flag | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `--param` | `[]string` | No | -- | Query parameter as `key=value` (repeatable). Values are auto-typed by the API. |
-| `--performance` | `string` | No | `medium` | Performance tier: `medium` (standard) or `large` (higher compute, more credits) |
+| `--performance` | `string` | No | (auto) | Performance tier override: `free`, `medium`, or `large`. Omit unless the user asks, the query is complex, or a previous run timed out. |
 | `--limit` | `int` | No | `0` | Maximum rows to display (`0` = all rows) |
 | `--no-wait` | `bool` | No | `false` | Submit and exit immediately without waiting for results |
 | `-o, --output` | `string` | No | `text` | Output format: `text` or `json` |
@@ -97,7 +97,7 @@ dune query run-sql --sql <SQL> [flags]
 |------|------|----------|---------|-------------|
 | `--sql` | `string` | Yes | -- | DuneSQL query to execute |
 | `--param` | `[]string` | No | -- | Query parameter as `key=value` (repeatable). Values are auto-typed by the API. |
-| `--performance` | `string` | No | `medium` | Performance tier: `medium` (standard) or `large` (higher compute, more credits) |
+| `--performance` | `string` | No | (auto) | Performance tier override: `free`, `medium`, or `large`. Omit unless the user asks, the query is complex, or a previous run timed out. |
 | `--limit` | `int` | No | `0` | Maximum rows to display (`0` = all rows) |
 | `--no-wait` | `bool` | No | `false` | Submit and exit immediately without waiting for results |
 | `-o, --output` | `string` | No | `text` | Output format: `text` or `json` |


### PR DESCRIPTION
Specify perf tiers explicitly in certain situations. By default omit.