### PR TITLE
Fix invalid SQL and incomplete viz options in dashboard example

### DIFF
--- a/skills/dune/SKILL.md
+++ b/skills/dune/SKILL.md
@@ -200,13 +200,13 @@ dune execution results 01ABC... -o json
 
 ```bash
 # 1. Create queries for each section
-QUERY_ID=$(dune query create --name "Daily Volume" --sql "SELECT date_trunc('day', block_time) AS day, SUM(amount) AS volume FROM trades GROUP BY 1 ORDER BY 1" -o json | jq -r '.query_id')
+QUERY_ID=$(dune query create --name "Daily Volume" --sql "SELECT date_trunc('day', block_time) AS day, SUM(amount_usd) AS volume FROM dex.trades WHERE block_time >= NOW() - INTERVAL '30' DAY GROUP BY 1 ORDER BY 1" -o json | jq -r '.query_id')
 
 # 2. Execute to verify data
 dune query run $QUERY_ID -o json
 
 # 3. Create visualizations for each query
-VIZ_ID=$(dune viz create --query-id $QUERY_ID --name "Daily Volume Chart" --type chart --options '{"globalSeriesType":"line","columnMapping":{"day":"x","volume":"y"}}' -o json | jq -r '.id')
+VIZ_ID=$(dune viz create --query-id $QUERY_ID --name "Daily Volume Chart" --type chart --options '{"globalSeriesType":"line","sortX":true,"columnMapping":{"day":"x","volume":"y"},"seriesOptions":{"volume":{"type":"line","yAxis":0,"zIndex":0,"name":"Volume"}},"xAxis":{"title":{"text":"Day"}},"yAxis":[{"title":{"text":"Volume (USD)"}}],"legend":{"enabled":true},"series":{"stacking":null}}' -o json | jq -r '.id')
 
 # 4. Assemble the dashboard
 dune dashboard create --name "Trading Dashboard" \


### PR DESCRIPTION
## Summary

The "Build a Dashboard from Scratch" example in `skills/dune/SKILL.md` had two issues that would cause the workflow to fail if followed verbatim.

**Invalid SQL.** The example used `FROM trades` (no such table) with `SUM(amount)` (no such column) and no partition filter on `block_time`, violating the skill's own partition filter rule in `dunesql-cheatsheet.md`. Fixed to use `dex.trades` with `amount_usd` and a 30-day partition filter.

**Incomplete chart options.** The `--options` JSON omitted the required fields `sortX`, `seriesOptions`, `xAxis`, `yAxis`, `legend`, and `series` listed in `visualization-management.md`. The file itself flags missing `seriesOptions` as a common mistake. Aligned the example with the minimum required template in the reference.

## Test plan

- [ ] Run the updated SQL via `dune query run-sql` to confirm `dex.trades.amount_usd` resolves and the query completes
- [ ] Run `dune viz create` with the updated `--options` JSON and verify the resulting chart renders correctly
