### PR TITLE
Allow small, medium and large engines

### DIFF
--- a/skills/dune/SKILL.md
+++ b/skills/dune/SKILL.md
@@ -74,7 +74,7 @@ Dune uses **DuneSQL**, a Trino-based SQL dialect, as its query engine. Key point
 
 ### Performance Tiers
 
-Available tiers: `free`, `medium`, `large`. **Do not pass `--performance` by default** — omit it and the API auto-selects. Only provide it when:
+Available tiers: `small`, `medium`, `large`. **Do not pass `--performance` by default** — omit it and the API auto-selects. Only provide it when:
 
 - The user explicitly requests a tier
 - The query is clearly complex (heavy joins, large aggregations)

--- a/skills/dune/references/query-execution.md
+++ b/skills/dune/references/query-execution.md
@@ -31,7 +31,7 @@ dune query run <query-id> [flags]
 | Flag | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `--param` | `[]string` | No | -- | Query parameter as `key=value` (repeatable). Values are auto-typed by the API. |
-| `--performance` | `string` | No | (auto) | Performance tier override: `free`, `medium`, or `large`. Omit unless the user asks, the query is complex, or a previous run timed out. |
+| `--performance` | `string` | No | (auto) | Performance tier override: `small`, `medium`, or `large`. Omit unless the user asks, the query is complex, or a previous run timed out. |
 | `--limit` | `int` | No | `0` | Maximum rows to display (`0` = all rows) |
 | `--no-wait` | `bool` | No | `false` | Submit and exit immediately without waiting for results |
 | `-o, --output` | `string` | No | `text` | Output format: `text` or `json` |
@@ -97,7 +97,7 @@ dune query run-sql --sql <SQL> [flags]
 |------|------|----------|---------|-------------|
 | `--sql` | `string` | Yes | -- | DuneSQL query to execute |
 | `--param` | `[]string` | No | -- | Query parameter as `key=value` (repeatable). Values are auto-typed by the API. |
-| `--performance` | `string` | No | (auto) | Performance tier override: `free`, `medium`, or `large`. Omit unless the user asks, the query is complex, or a previous run timed out. |
+| `--performance` | `string` | No | (auto) | Performance tier override: `small`, `medium`, or `large`. Omit unless the user asks, the query is complex, or a previous run timed out. |
 | `--limit` | `int` | No | `0` | Maximum rows to display (`0` = all rows) |
 | `--no-wait` | `bool` | No | `false` | Submit and exit immediately without waiting for results |
 | `-o, --output` | `string` | No | `text` | Output format: `text` or `json` |


### PR DESCRIPTION
Updates Dune CLI documentation to reflect the new --performance tier naming: small, medium, and large (replacing free).